### PR TITLE
Added a setMeta method (on client).

### DIFF
--- a/lib/both.js
+++ b/lib/both.js
@@ -17,6 +17,12 @@ DocHead = {
   addMeta(info) {
     this._addTag(info, 'meta');
   },
+  setMeta(info) {
+    if (!Meteor.isServer) {
+      this._removeTag( info.name );
+      this.addMeta(info);
+    }
+  },
   addLink(info) {
     this._addTag(info, 'link');
   },
@@ -42,6 +48,9 @@ DocHead = {
     } else {
       this._addToHead(meta);
     }
+  },
+  _removeTag(metaName) {
+    $(`meta[name="${metaName}"`).remove();
   },
   _addToHead(html) {
     // only work there is kadira:flow-router-ssr

--- a/lib/both.js
+++ b/lib/both.js
@@ -53,10 +53,6 @@ DocHead = {
     if (Meteor.isClient) {
       $(`meta[name="${metaName}"`).remove();
     }
-    if (Meteor.isServer) {
-      let ssrContext = FlowRouter.ssrContext.get();
-      console.log( ssrContext );
-    }
   },
   _addToHead(html) {
     // only work there is kadira:flow-router-ssr

--- a/lib/both.js
+++ b/lib/both.js
@@ -18,10 +18,10 @@ DocHead = {
     this._addTag(info, 'meta');
   },
   setMeta(info) {
-    if (!Meteor.isServer) {
+    if (Meteor.isClient) {
       this._removeTag( info.name );
-      this.addMeta(info);
     }
+    this.addMeta(info);
   },
   addLink(info) {
     this._addTag(info, 'link');
@@ -50,7 +50,13 @@ DocHead = {
     }
   },
   _removeTag(metaName) {
-    $(`meta[name="${metaName}"`).remove();
+    if (Meteor.isClient) {
+      $(`meta[name="${metaName}"`).remove();
+    }
+    if (Meteor.isServer) {
+      let ssrContext = FlowRouter.ssrContext.get();
+      console.log( ssrContext );
+    }
   },
   _addToHead(html) {
     // only work there is kadira:flow-router-ssr

--- a/test/client.js
+++ b/test/client.js
@@ -18,6 +18,18 @@ Tinytest.add('Client - addMeta', function(test) {
   test.equal(metaDom.attr('content'), metaInfo.content);
 });
 
+Tinytest.add('Client - setMeta', function(test) {
+  const metaInfo = {name: "description", content: "awesome content"};
+  const metaInfoUpdated = {name: "description", content: "NEW content"};
+  DocHead.setMeta(metaInfo);
+  test.equal($('meta[name=description]').attr('name'), metaInfo.name);
+  test.equal($('meta[name=description]').attr('content'), metaInfo.content);
+  test.equal( $('meta[name=description]').length, 1 );
+  DocHead.setMeta(metaInfoUpdated);
+  test.equal($('meta[name=description]').attr('content'), metaInfoUpdated.content);
+  test.equal( $('meta[name=description]').length, 1 );
+});
+
 Tinytest.add('Client - addLdJsonScript', function(test, done) {
   const snippet = {
     '@context': 'http://schema.org',

--- a/test/server.js
+++ b/test/server.js
@@ -31,6 +31,23 @@ Tinytest.addAsync('Server - addMeta', function(test, done) {
   DocHead.addMeta(metaInfo);
 });
 
+Tinytest.addAsync('Server - setMeta', function(test, done) {
+  const metaInfo = {name: "description", content: "hello content"};
+  const metaInfo2 = {name: "description", content: "NEW content"};
+  let handle = onSsrContext(function(html) {
+    const metaTag = `<meta name="${metaInfo.name}" content="${metaInfo.content}" dochead="1"/>`;
+    test.equal(html, metaTag);
+    let handle = onSsrContext( html => {
+      const metaTag2 = `<meta name="${metaInfo2.name}" content="${metaInfo2.content}" dochead="1"/>`;
+      test.equal(html, metaTag2);
+      handle.stop();
+      done();
+    });
+    DocHead.setMeta(metaInfo2);
+  });
+  DocHead.setMeta(metaInfo);
+});
+
 Tinytest.addAsync('Server - addLdJsonScript', function(test, done) {
   const snippet = {
     '@context': 'http://schema.org',


### PR DESCRIPTION
Added a setMeta method which unlike addMeta _does not append new meta tags on each call_.

For example: if you run `DocHead.addMeta({ name: "description", content: "Some content" })` you will end up with TWO `<meta name="description">` tags in your `<head>`, which you now can avoid by using the setMeta method (which makes sure there is always at most one tag at a time).

Only added the method on client since it don't make (as much) sense on the server to run the addMeta more than once.
