### PR TITLE
pass SSR context

### DIFF
--- a/lib/both.js
+++ b/lib/both.js
@@ -5,20 +5,20 @@ if (Package['kadira:flow-router-ssr']) {
 
 DocHead = {
   currentTitle: null,
-  setTitle(title) {
+  setTitle(title, context) {
     if (Meteor.isClient) {
       document.title = title;
     } else {
       this.currentTitle = title;
       const titleHtml = `<title>${title}</title>`;
-      this._addToHead(titleHtml);
+      this._addToHead(titleHtml, context);
     }
   },
-  addMeta(info) {
-    this._addTag(info, 'meta');
+  addMeta(info, context) {
+    this._addTag(info, 'meta', context);
   },
-  addLink(info) {
-    this._addTag(info, 'link');
+  addLink(info, context) {
+    this._addTag(info, 'link', context);
   },
   getTitle() {
     if (Meteor.isClient) {
@@ -28,26 +28,28 @@ DocHead = {
   },
   addLdJsonScript(jsonObj) {
     const strObj = JSON.stringify(jsonObj);
-    this._addLdJsonScript(strObj);
+    this._addLdJsonScript(strObj, context);
   },
   loadScript(url, options, callback) {
     if (Meteor.isClient) {
       npmLoadScript(url, options, callback);
     }
   },
-  _addTag(info, tag) {
+  _addTag(info, tag, context) {
     const meta = this._buildTag(info, tag);
     if (Meteor.isClient) {
       $('head').append(meta);
     } else {
-      this._addToHead(meta);
+      this._addToHead(meta, context);
     }
   },
-  _addToHead(html) {
+  _addToHead(html, context) {
     // only work there is kadira:flow-router-ssr
     if (!FlowRouter) {
       return;
     }
+    if(context)
+      context.addToHead(html);
     let ssrContext = FlowRouter.ssrContext.get();
     if (ssrContext) {
       ssrContext.addToHead(html);
@@ -67,7 +69,7 @@ DocHead = {
     if (Meteor.isClient) {
       $('head').append(scriptTag);
     } else {
-      this._addToHead(scriptTag);
+      this._addToHead(scriptTag, context);
     }
   },
   removeDocHeadAddedTags() {


### PR DESCRIPTION
This PR concerns this issue on FlowRouter : https://github.com/kadirahq/flow-router/issues/205

When ReactLayout.render is called asynchronousely, the ssr context is not accessible anymore. This is a double PR (I'ma making the same for DocHead). It just add the context as an optionnal parametter of the render and _addToHead functions.

So in the action hook of the route constructor in flow router, you can now do this :

```
action( params, queryParams ) {

    let context;
    if ( Meteor.isServer )
        context = FlowRouter.ssrContext.get();

    Meteor.call( 'getAsyncData', ( err, data ) => {

        DocHead.setTitle( data.title, context );

        DocHead.addMeta( {
            name: 'description',
            content: data.description
        }, context );

        ReactLayout.render( ReactLayouts.MainLayout, {
            content: <ReactView.MyView data={ data } />,
        }, context );

    } );

}
```

There's probably a smarter way, but this one works.
