### PR TITLE
added hasLink, and removeLink public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ var linkInfo = {rel: "icon", type: "image/png", href: "/icon.png"};
 DocHead.addLink(linkInfo);
 ~~~
 
+#### DocHead.hasLink(metaInfo)
+
+Check if a Link tag with a matching `.href` attribute exists in the head.
+
+~~~js
+var linkInfo = {rel: "icon", type: "image/png", href: "/icon.png"};
+DocHead.hasLink(linkInfo);
+~~~
+
+#### DocHead.removeLink(metaInfo)
+
+Removes all link tags with a matching `.href` attribute.
+
+~~~js
+var linkInfo = {rel: "icon", type: "image/png", href: "/icon.png"};
+DocHead.removeLink(linkInfo);
+~~~
+
 #### DocHead.addLdJsonScript(jsonObj)
 
 Add a Script tag with type of `application/ld+json`.

--- a/lib/both.js
+++ b/lib/both.js
@@ -25,6 +25,16 @@ DocHead = {
   addLink(info) {
     this._addTag(info, 'link');
   },
+  hasLink(info) {
+    if (Meteor.isClient) {
+      return this._hasTag(info, 'link');
+    }
+  },
+  removeLink(info) {
+    if (Meteor.isClient) {
+      this._removeTag(info, 'link');
+    }
+  },
   getTitle() {
     if (Meteor.isClient) {
       titleDependency.depend();
@@ -48,6 +58,26 @@ DocHead = {
     } else {
       this._addToHead(meta);
     }
+  },
+  _hasTag(info, tag) {
+    return !!this._findTagByHref(info.href, tag);
+  },
+  _removeTag(info, tag) {
+    const elements = document.querySelectorAll(tag);
+    for (let element of elements) {
+      if (element.getAttribute('href') === info.href) {
+        element.parentNode.removeChild(element);
+      }
+    }
+  },
+  _findTagByHref(href, tag) {
+    const elements = document.querySelectorAll(tag);
+    for (let element of elements) {
+      if (element.getAttribute('href') === href) {
+        return element;
+      }
+    }
+    return null
   },
   _addToHead(html) {
     // only work there is kadira:flow-router-ssr


### PR DESCRIPTION
I added hasLink and removeLink public methods, which match on the `.href` property of metaData, and the DOM element.

These will match any link in the head, not just dochead created ones.

Addresses Issue #35 
